### PR TITLE
Deprecate NousResearch/Nous-Hermes-Llama2-70b

### DIFF
--- a/prem_utils/models.json
+++ b/prem_utils/models.json
@@ -470,7 +470,8 @@
                     "model_type": "text2text",
                     "context_window": 4096,
                     "input_cost_per_token": 0.0000009,
-                    "output_cost_per_token": 0.0000009
+                    "output_cost_per_token": 0.0000009,
+                    "deprecated": true
                 },
                 {
                     "slug": "Open-Orca/Mistral-7B-OpenOrca",


### PR DESCRIPTION
The only model of issue [https://github.com/premAI-io/prem-saas/issues/896](https://github.com/premAI-io/prem-saas/issues/896) is `NousResearch/Nous-Hermes-Llama2-70b`