### PR TITLE
add models tier data

### DIFF
--- a/prem_utils/models.json
+++ b/prem_utils/models.json
@@ -411,7 +411,7 @@
                     "output_cost_per_token": 0.00012,
                     "alias": "mistral-large",
                     "group": "mistral",
-                    "available_on_free_plan": true,
+                    "available_on_free_plan": false,
                     "parameters":
                     {
                         "temperature": {
@@ -450,7 +450,7 @@
                     "output_cost_per_token": 0.00012,
                     "alias": "gpt-4-eu",
                     "group": "gpt",
-                    "available_on_free_plan": true,
+                    "available_on_free_plan": false,
                     "parameters":
                     {
                         "temperature": {
@@ -1337,6 +1337,7 @@
             "provider": "prem",
             "models": [
                 {
+                    "tier": "low",
                     "slug": "phi1_5",
                     "model_type": "text2text",
                     "context_window": 2048,
@@ -1346,6 +1347,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "phi2",
                     "model_type": "text2text",
                     "context_window": 2048,
@@ -1355,6 +1357,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "tiny_llama",
                     "model_type": "text2text",
                     "context_window": 2048,
@@ -1382,6 +1385,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "gemma",
                     "model_type": "text2text",
                     "context_window": 2048,
@@ -1391,6 +1395,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "prem-1b-chat",
                     "model_type": "text2text",
                     "coming_soon": true,
@@ -1400,6 +1405,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "prem-1b-json",
                     "model_type": "text2text",
                     "coming_soon": true,
@@ -1409,6 +1415,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "prem-1b-sum",
                     "model_type": "text2text",
                     "coming_soon": true,

--- a/prem_utils/models.json
+++ b/prem_utils/models.json
@@ -339,6 +339,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "embed-english-v3.0",
                     "model_type": "text2vector",
                     "output_cost_per_token": 0.0000001,
@@ -350,6 +351,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "embed-english-light-v3.0",
                     "model_type": "text2vector",
                     "output_cost_per_token": 0.0000001,
@@ -361,6 +363,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "embed-multilingual-v3.0",
                     "model_type": "text2vector",
                     "output_cost_per_token": 0.0000001,
@@ -372,6 +375,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "embed-multilingual-light-v3.0",
                     "model_type": "text2vector",
                     "output_cost_per_token": 0.0000001,
@@ -383,6 +387,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "coral",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -398,7 +403,7 @@
             "provider": "azure-mistral",
             "models": [
                 {
-                    "tier": "medium",
+                    "tier": "high",
                     "slug": "mistral-large",
                     "model_type": "text2text",
                     "context_window": 32768,
@@ -676,6 +681,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "text-embedding-3-small",
                     "model_type": "text2vector",
                     "context_window": 8191,
@@ -690,6 +696,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "text-embedding-3-large",
                     "model_type": "text2vector",
                     "context_window": 8191,
@@ -704,6 +711,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "text-embedding-ada-002",
                     "model_type": "text2vector",
                     "context_window": 8191,
@@ -718,6 +726,7 @@
                     ]
                 },
                 {
+                    "tier": "medium",
                     "slug": "dall-e-3",
                     "model_type": "text2image",
                     "cost_per_image": 0.120,
@@ -1310,6 +1319,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "mistral-embed",
                     "model_type": "text2vector",
                     "context_window": 4096,

--- a/prem_utils/models.json
+++ b/prem_utils/models.json
@@ -4,6 +4,7 @@
             "provider": "anthropic",
             "models": [
                 {
+                    "tier": "high",
                     "slug": "claude-3-opus-20240229",
                     "alias": "claude-3-opus",
                     "model_type": "text2text",
@@ -47,6 +48,7 @@
                     ]
                 },
                 {
+                    "tier": "medium",
                     "slug": "claude-3-sonnet-20240229",
                     "alias": "claude-3-sonnet",
                     "model_type": "text2text",
@@ -90,6 +92,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "claude-3-haiku-20240307",
                     "alias": "claude-3-haiku",
                     "model_type": "text2text",
@@ -156,6 +159,7 @@
             "provider": "cohere",
             "models": [
                 {
+                    "tier": "low",
                     "slug": "command-light",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -200,6 +204,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "command",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -244,6 +249,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "command-r",
                     "model_type": "text2text",
                     "context_window": 128000,
@@ -288,6 +294,7 @@
                     ]
                 },
                 {
+                    "tier": "medium",
                     "slug": "command-r-plus",
                     "model_type": "text2text",
                     "context_window": 128000,
@@ -391,6 +398,7 @@
             "provider": "azure-mistral",
             "models": [
                 {
+                    "tier": "medium",
                     "slug": "mistral-large",
                     "model_type": "text2text",
                     "context_window": 32768,
@@ -429,6 +437,7 @@
             "provider": "azure",
             "models": [
                 {
+                    "tier": "high",
                     "slug": "gpt-4-32k-azure",
                     "model_type": "text2text",
                     "context_window": 32768,
@@ -488,6 +497,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "gpt-35-turbo-16k-azure",
                     "model_type": "text2text",
                     "context_window": 16385,
@@ -537,6 +547,7 @@
             "provider": "openai",
             "models": [
                 {
+                    "tier": "medium",
                     "slug": "gpt-4-turbo-preview",
                     "model_type": "text2text",
                     "context_window": 128000,
@@ -612,6 +623,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "gpt-3.5-turbo",
                     "model_type": "text2text",
                     "context_window": 16385,
@@ -1166,6 +1178,7 @@
             "provider": "mistralai",
             "models": [
                 {
+                    "tier": "low",
                     "slug": "mistral-tiny",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -1209,6 +1222,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "mistral-small",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -1252,6 +1266,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "mistral-medium",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -1398,6 +1413,7 @@
             "provider": "openrouter",
             "models": [
                 {
+                    "tier": "low",
                     "slug": "openrouter/meta-llama/llama-3-8b-instruct",
                     "model_type": "text2text",
                     "context_window": 8192,
@@ -1440,6 +1456,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/meta-llama/llama-3-70b-instruct",
                     "model_type": "text2text",
                     "context_window": 8192,
@@ -1578,6 +1595,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/pygmalionai/mythalion-13b",
                     "model_type": "text2text",
                     "context_window": 8192,
@@ -1655,6 +1673,7 @@
                     }
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/gryphe/mythomax-l2-13b",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -1757,6 +1776,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/undi95/remm-slerp-l2-13b",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -1811,6 +1831,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/01-ai/yi-34b-chat",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -1864,6 +1885,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/togethercomputer/stripedhyena-nous-7b",
                     "model_type": "text2text",
                     "context_window": 32768,
@@ -1936,6 +1958,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/huggingfaceh4/zephyr-7b-beta",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -2002,6 +2025,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/google/gemini-pro",
                     "model_type": "text2text",
                     "context_window": 91728,
@@ -2061,6 +2085,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/austism/chronos-hermes-13b",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -2103,6 +2128,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/mistralai/mixtral-8x22b",
                     "model_type": "text2text",
                     "context_window": 65536,
@@ -2163,6 +2189,7 @@
                     "deprecated": true
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/cognitivecomputations/dolphin-mixtral-8x7b",
                     "model_type": "text2text",
                     "context_window": 32769,
@@ -2204,6 +2231,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "openrouter/rwkv/rwkv-5-world-3b",
                     "model_type": "text2text",
                     "context_window": 10000,
@@ -2509,6 +2537,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "anyscale/meta-llama/Llama-2-13b-chat-hf",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -2551,6 +2580,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "anyscale/meta-llama/Llama-2-70b-chat-hf",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -2593,6 +2623,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "anyscale/codellama/CodeLlama-70b-Instruct-hf",
                     "model_type": "text2text",
                     "context_window": 4096,
@@ -2634,6 +2665,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "anyscale/mistralai/Mistral-7B-Instruct-v0.1",
                     "model_type": "text2text",
                     "context_window": 16384,
@@ -2675,6 +2707,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "anyscale/mistralai/Mixtral-8x7B-Instruct-v0.1",
                     "model_type": "text2text",
                     "context_window": 32768,
@@ -2717,6 +2750,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "anyscale/google/gemma-7b-it",
                     "model_type": "text2text",
                     "context_window": 8192,
@@ -2785,6 +2819,7 @@
             "provider": "groq",
             "models": [
                 {
+                    "tier": "low",
                     "slug": "groq/llama3-8b-8192",
                     "model_type": "text2text",
                     "context_window": 8192,
@@ -2826,6 +2861,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "groq/llama3-70b-8192",
                     "model_type": "text2text",
                     "context_window": 8192,
@@ -2908,6 +2944,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "groq/mixtral-8x7b-32768",
                     "model_type": "text2text",
                     "context_window": 32768,
@@ -2949,6 +2986,7 @@
                     ]
                 },
                 {
+                    "tier": "low",
                     "slug": "groq/gemma-7b-it",
                     "model_type": "text2text",
                     "context_window": 8192,


### PR DESCRIPTION
fixes #120

tiers of deprecated models is skipped.
tiers of models which are not used in prod, and doesn't have `input_cost_per_token` and `output_cost_per_token` are also skipped

it includes:
```
@cf/baai/bge-base-en-v1.5                         
@cf/baai/bge-large-en-v1.5                        
@cf/baai/bge-small-en-v1.5                        
replicate/all-mpnet-base-v2:b6b7585c9640cd7a9572c6
mamba                                             
stable_lm2                                        
anyscale/thenlper/gte-large                       
anyscale/BAAI/bge-large-en-v1.5                   
```

to the followings model, I added low, considering they are 1b-2b models

```
phi1_5                                             
phi2                                               
tiny_llama                                         
gemma                                              
prem-1b-chat                                       
prem-1b-json                                       
prem-1b-sum                                        
```

